### PR TITLE
Update dead link

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Example code that demonstrates how to use StashJS.
   npm install
   ```
 
-2. Have a [CipherStash profile setup](https://docs.cipherstash.com/tutorials/getting-started/install-stash-cli.html):
+2. Have a [CipherStash profile setup](https://docs.cipherstash.com/reference/create-an-account.html):
 
   ```bash
   stash login --workspace <workspaceID>


### PR DESCRIPTION
The previous link doesn't resolve anymore, linked to the "Creating a CipherStash Account" page